### PR TITLE
Add md5 check + BUMP sonarquube default version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 workspace: /root
 
 # Default to the latest LTS release.
-sonar_download_url: https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-4.5.6.zip
-sonar_version_directory: sonarqube-4.5.6
+sonar_download_url: https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-4.5.7.zip
+sonar_version_directory: sonarqube-4.5.7
 
 # MySQL database connection details.
 sonar_mysql_username: sonar


### PR DESCRIPTION
# Description

- BUMP sonarquube to version `4.5.7`
- Add md5 integrity check when downloading archive